### PR TITLE
Chore/unit test

### DIFF
--- a/config/database.py
+++ b/config/database.py
@@ -14,7 +14,7 @@ from databases import Database
 SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL")
 
 DB_ENGINE = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+    SQLALCHEMY_DATABASE_URL
 )  # connect_args={"check_same_thread": False} is needed only for SQLite.
 # It's not needed for other databases.
 

--- a/core/deps.py
+++ b/core/deps.py
@@ -5,29 +5,10 @@ from fastapi import Depends, HTTPException
 from models.user import User
 from orm.users import users_orm
 from auth.auth_bearer import jwt_bearer
-from config.database import SessionLocal
 
 # 3rd Party Imports
 import jwt
 from decouple import config
-
-
-def get_db():
-    """
-    This function creates a database session,
-    yield it to the get_db function, rollback the transaction
-    if there's an exception and then finally closes the session.
-
-    Yields:
-        db: scoped database session
-    """
-    db = SessionLocal()
-    try:
-        yield db
-    except Exception:
-        db.rollback()
-    finally:
-        db.close()
 
 
 async def get_current_user(token: str = Depends(jwt_bearer)) -> User:

--- a/core/settings.py
+++ b/core/settings.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     JWT_SECRET_KEY: str = config("JWT_SECRET", cast=str)
     JWT_ALGORITHM: str = config("JWT_ALGORITHM", cast=str)
     TOKEN_LIFETIME: int = config("TOKEN_LIFETIME", cast=int)
+    USE_TEST_DB: bool = config("USE_TEST_DB", cast=bool)
 
     TITLE: str = "Ledger System"
     DESCRIPTION: str = "A fintech backend ledger system built with FastAPI."

--- a/ledger/router.py
+++ b/ledger/router.py
@@ -3,13 +3,7 @@ from fastapi import APIRouter, Depends
 
 # Own Imports
 from auth.auth_bearer import jwt_bearer
-from core.deps import get_db
 
 
 # initialize router
-router = APIRouter(
-    dependencies=[
-        Depends(jwt_bearer),
-        Depends(get_db),
-    ]
-)
+router = APIRouter(dependencies=[Depends(jwt_bearer)])

--- a/ledger/services/operations.py
+++ b/ledger/services/operations.py
@@ -31,7 +31,7 @@ class LedgerOperations:
 
     async def deposit_money_to_wallet(
         self, deposit: WalletDeposit
-    ) -> UserWallet:
+    ) -> None:
         """
         This function deposit x amount to the user wallet.
 
@@ -45,11 +45,10 @@ class LedgerOperations:
         topup_wallet.amount += deposit.amount
 
         self.db.commit()
-        self.db.refresh(topup_wallet, ["amount"])
 
     async def withdraw_money_from_wallet(
         self, withdraw: WalletWithdraw
-    ) -> UserWallet:
+    ) -> None:
         """
         The function withdraws x amount from the user wallet.
 
@@ -63,11 +62,10 @@ class LedgerOperations:
         withdraw_wallet.amount -= withdraw.amount
 
         self.db.commit()
-        self.db.refresh(withdraw_wallet, ["amount"])
 
     async def withdraw_from_to_wallet_transfer(
         self, withdraw: Wallet2WalletTransfer
-    ) -> UserWallet:
+    ) -> None:
         """
         This function is responsible for transferring x amount
         from wallet y to wallet z.
@@ -87,20 +85,16 @@ class LedgerOperations:
         to_wallet.amount += withdraw.amount
 
         self.db.commit()
-        self.db.refresh(from_wallet, ["amount"])
-        self.db.refresh(to_wallet, ["amount"])
 
     async def withdraw_from_to_user_wallet_transfer(
         self, withdraw: Wallet2UserWalletTransfer
-    ) -> UserWallet:
+    ) -> None:
         """
         This function is responsible for transferring x amount
         from wallet y to user z wallet.
 
         :param withdraw: schemas.Wallet2UserWalletTransfer
         :type withdraw: schemas.Wallet2UserWalletTransfer
-
-        :return: The to_wallet is being returned.
         """
 
         from_wallet = ledger_orm.partial_filter(
@@ -114,10 +108,6 @@ class LedgerOperations:
         to_wallet.amount += withdraw.amount
 
         self.db.commit()
-        self.db.refresh(from_wallet, ["amount"])
-        self.db.refresh(to_wallet, ["amount"])
-
-        return to_wallet
 
     async def get_total_wallet_balance(self, user_id: int) -> int:
         """

--- a/orm/aggregate.py
+++ b/orm/aggregate.py
@@ -2,7 +2,7 @@
 from sqlalchemy import func
 
 # Own Imports
-from orm.ledger import BaseLedgerORM, Userwallet, SessionLocal
+from orm.ledger import BaseLedgerORM, Userwallet
 
 
 class LedgerAggregateORM(BaseLedgerORM):
@@ -20,4 +20,4 @@ class LedgerAggregateORM(BaseLedgerORM):
         )
 
 
-ledger_aggregate_orm = LedgerAggregateORM(SessionLocal())
+ledger_aggregate_orm = LedgerAggregateORM()

--- a/orm/base.py
+++ b/orm/base.py
@@ -1,9 +1,39 @@
 # SQLAlchemy Imports
 from sqlalchemy.orm import Session
 
+# Own Imports
+from config.database import SessionLocal
+from tests.conftest import _get_test_db
+from core.settings import ledger_settings
+
 
 class ORMSessionMixin:
     """Base orm session mixin for interacting with the database."""
 
-    def __init__(self, orm: Session):
-        self.orm = orm
+    def __init__(self):
+        """
+        If we're not using the test database, then get the next database session from the database pool.
+        Otherwise, get the next database session from the test database pool.
+        """
+        self.orm: Session = (
+            self.get_db().__next__()
+            if not ledger_settings.USE_TEST_DB
+            else _get_test_db().__next__()
+        )
+
+    def get_db(self):
+        """
+        This function creates a database session,
+        yield it to the get_db function, rollback the transaction
+        if there's an exception and then finally closes the session.
+
+        Yields:
+            db: scoped database session
+        """
+        db = SessionLocal()
+        try:
+            yield db
+        except Exception:
+            db.rollback()
+        finally:
+            db.close()

--- a/orm/ledger.py
+++ b/orm/ledger.py
@@ -7,7 +7,6 @@ from fastapi import HTTPException
 # Own Imports
 from orm.base import ORMSessionMixin
 from schemas.ledger import WalletCreate
-from config.database import SessionLocal
 from models.ledger import Wallet as Userwallet
 
 
@@ -116,8 +115,8 @@ class LedgerORM(BaseLedgerORM):
         # -----------
 
         # solution 1
-        # hange the value directly with the column value
-        wallet = self.partial_list().filter_by(id=wallet_id).update(kwargs)
+        # update the value directly with the column value
+        # wallet = self.partial_list().filter_by(id=wallet_id).update(kwargs)
 
         # solution 2
         # locks row for this particular wallet
@@ -144,4 +143,4 @@ class LedgerORM(BaseLedgerORM):
         return True
 
 
-ledger_orm = LedgerORM(SessionLocal())
+ledger_orm = LedgerORM()

--- a/orm/users.py
+++ b/orm/users.py
@@ -8,7 +8,6 @@ from sqlalchemy.orm import joinedload
 from models.user import User
 from schemas.user import UserCreate
 from orm.base import ORMSessionMixin
-from config.database import SessionLocal
 
 
 class BaseUsersORM(ORMSessionMixin):
@@ -81,4 +80,4 @@ class UsersORM(BaseUsersORM):
         return user
 
 
-users_orm = UsersORM(SessionLocal())
+users_orm = UsersORM()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+filterwarnings =
+    ignore:DeprecationWarning
+    ignore:function ham\(\) is deprecated:DeprecationWarning

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 # Stdlib Imports
 import sys
 import os
+import warnings
 
 # SQLAlchemy Impprts
 from sqlalchemy import create_engine
@@ -11,13 +12,17 @@ from models.user import Base
 
 # Third Party Imports
 import pytest
+import alembic
+from alembic.config import Config
 
 
-# this is to include backend dir in sys.path so that we can import from db, main.py
+# this is to include backend dir in sys.path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-
+# Initialize test database
 SQLALCHEMY_DATABASE_URL = "sqlite:///./test_db.sqlite"
+
+# Create Database engine
 engine = create_engine(
     SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
 )
@@ -26,18 +31,22 @@ engine = create_engine(
 SessionTesting = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
-
-@pytest.fixture()
 def create_tables():
     """
-    Create a fresh database on each test case.
+    This function creates all the tables in the database,
+    then drops them.
     """
-    Base.metadata.create_all(engine)  # Create the tables.    
+
+    Base.metadata.create_all(engine)
     yield
     Base.metadata.drop_all(engine)
 
 
 def _get_test_db():
+
+    # Call method to create tables
+    create_tables()
+
     session = SessionTesting()
     try:
         yield session

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import warnings
 
 # SQLAlchemy Impprts
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, scoped_session
 
 # Own Imports
 from models.user import Base
@@ -28,7 +28,8 @@ engine = create_engine(
 )
 
 # Use connect_args parameter only with sqlite
-SessionTesting = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+SessionTesting = scoped_session(session_factory)
 
 
 def create_tables():

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,43 +1,181 @@
+# Stdlib Imports
+import json
+import random
+import string
+from typing import Tuple
+
 # Own Imports
+from orm.users import users_orm
+from orm.ledger import ledger_orm
 from tests.test_user import client
 
 # Third Party Imports
 import pytest
 
 
-async def login_user():
+name = "".join(random.choice(string.ascii_lowercase) for i in range(6))
+email = name + "@email.com"
+password = name + "_weakpassword"
+
+wallet_title = "".join(random.choice(string.ascii_lowercase) for i in range(6))
+
+
+async def create_user() -> Tuple[dict, str]:
+    """Function to create a user."""
+
+    payload = {"name": name, "email": email, "password": password}
+    print("Email: ", email)
+    response = client.post("/register/", data=json.dumps(payload))
+    return response.json(), password
+
+
+async def login_user(u_email: str, u_password: str):
     """Function to login a user and get the access token."""
-    pass
+
+    payload = {"email": u_email, "password": u_password}
+    response = client.post("/login/", data=json.dumps(payload))
+
+    return response.json()["access_token"]
+
+
+async def get_user_id(u_email: str) -> int:
+    """Function to get the user id."""
+
+    user = await users_orm.get_email(u_email)
+    return user.id
 
 
 @pytest.mark.asyncio
 async def test_create_wallet():
     """Ensure an authenticated user can create a wallet."""
-    pass
+
+    user, u_password = await create_user()
+    token = await login_user(user["email"], u_password)
+    user_id = await get_user_id(user["email"])
+
+    payload = {
+        "user": user_id,
+        "amount": random.randint(10000, 99999),
+        "title": wallet_title,
+    }
+    response = client.post(
+        "/wallets/",
+        data=json.dumps(payload),
+        headers={"Authorization": "Bearer " + token},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["user"] == user_id
+    assert response.json()["title"] == wallet_title
 
 
 @pytest.mark.asyncio
 async def test_get_wallets():
     """Ensure an authenticated user can get their wallets."""
-    pass
+
+    token = await login_user(email, password)
+    response = client.get(
+        "/wallets/", headers={"Authorization": "Bearer " + token}
+    )
+    assert response.status_code == 200
 
 
 @pytest.mark.asyncio
 async def test_deposit_money():
     """Ensure an authenticated user can deposit money."""
-    pass
+
+    user_id = await get_user_id(email)
+    token = await login_user(email, password)
+    wallets = await ledger_orm.filter(
+        **{"user_id": user_id, "skip": 0, "limit": 2}
+    )
+
+    payload = {"user": user_id, "amount": 5000, "id": wallets[0].id}
+    response = client.post(
+        "/deposit/",
+        data=json.dumps(payload),
+        headers={"Authorization": "Bearer " + token},
+    )
+
+    assert response.status_code == 200
+    assert (
+        response.json()["message"]
+        == f"NGN{payload['amount']} deposit successful!"
+    )
 
 
 @pytest.mark.asyncio
 async def test_withdraw_money():
     """Ensure an authenticated user can withdraw money."""
-    pass
+
+    user_id = await get_user_id(email)
+    token = await login_user(email, password)
+    wallets = await ledger_orm.filter(
+        **{"user_id": user_id, "skip": 0, "limit": 2}
+    )
+
+    payload = {"user": user_id, "amount": 5000, "id": wallets[0].id}
+    response = client.post(
+        "/withdraw/",
+        data=json.dumps(payload),
+        headers={"Authorization": "Bearer " + token},
+    )
+
+    assert response.status_code == 200
+    assert (
+        response.json()["message"]
+        == f"NGN{payload['amount']} withdrawn successful!"
+    )
 
 
 @pytest.mark.asyncio
 async def test_wallet_to_wallet_transfer():
     """Ensure an authenticated user can transfer from x to y wallet."""
-    pass
+
+    user_id = await get_user_id(email)
+    token = await login_user(email, password)
+
+    wallet_from = client.post(
+        "/wallets/",
+        data=json.dumps(
+            {
+                "user": user_id,
+                "amount": random.randint(10000, 99999),
+                "title": wallet_title,
+            }
+        ),
+        headers={"Authorization": "Bearer " + token},
+    )
+    wallet_to = client.post(
+        "/wallets/",
+        data=json.dumps(
+            {
+                "user": user_id,
+                "amount": random.randint(10000, 99999),
+                "title": wallet_title + "_2",
+            }
+        ),
+        headers={"Authorization": "Bearer " + token},
+    )
+
+    payload = {
+        "user": user_id,
+        "amount": 50000,
+        "wallet_from": wallet_from.json()["id"],
+        "wallet_to": wallet_to.json()["id"],
+    }
+    response = client.post(
+        "/transfer/wallet-to-wallet/",
+        data=json.dumps(payload),
+        headers={"Authorization": "Bearer " + token},
+    )
+
+    assert response.status_code == 200
+    assert (
+        response.json()["message"]
+        == f"NGN{payload['amount']} was transfered from \
+            W#{wallet_from.json()['id']} wallet to W#{wallet_to.json()['id']} wallet!"
+    )
 
 
 @pytest.mark.asyncio
@@ -50,10 +188,29 @@ async def test_wallet_to_user_transfer():
 @pytest.mark.asyncio
 async def test_total_wallet_balance():
     """Ensure an authenticated user can get the total balance of their wallets."""
-    pass
+
+    token = await login_user(email, password)
+    response = client.get(
+        "/balance/", headers={"Authorization": "Bearer " + token}
+    )
+
+    assert response.status_code == 200
 
 
 @pytest.mark.asyncio
 async def test_wallet_balance():
     """Ensure an authenticated user can get the balance of a particular wallet."""
-    pass
+
+    token = await login_user(email, password)
+    user_id = await get_user_id(email)
+    wallets = await ledger_orm.filter(
+        **{"user_id": user_id, "skip": 0, "limit": 2}
+    )
+
+    response = client.get(
+        "/balance/",
+        params={"wallet_id": wallets[0].id},
+        headers={"Authorization": "Bearer " + token},
+    )
+
+    assert response.status_code == 200

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,0 +1,48 @@
+# Own Imports
+from tests.test_user import client
+
+
+async def login_user():
+    """Function to login a user and get the access token."""
+    pass
+
+
+async def test_create_wallet():
+    """Ensure a user can create a wallet."""
+    pass
+
+
+async def test_get_wallets():
+    """Ensure an authenticated user can get their wallets."""
+    pass
+
+
+async def test_deposit_money():
+    """Ensure an authenticated user can deposit money."""
+    pass
+
+
+async def test_withdraw_money():
+    """Ensure an authenticated user can withdraw money."""
+    pass
+
+
+async def test_wallet_to_wallet_transfer():
+    """Ensure an authenticated user can transfer from x to y wallet."""
+    pass
+
+
+async def test_wallet_to_user_transfer():
+    """Ensure an authenticated user can transfer his their account to
+    another user's account."""
+    pass
+
+
+async def test_total_wallet_balance():
+    """Ensure an authenticated user can get the total balance of their wallets."""
+    pass
+
+
+async def test_wallet_balance():
+    """Ensure an authenticated user can get the balance of a particular wallet."""
+    pass

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,48 +1,59 @@
 # Own Imports
 from tests.test_user import client
 
+# Third Party Imports
+import pytest
+
 
 async def login_user():
     """Function to login a user and get the access token."""
     pass
 
 
+@pytest.mark.asyncio
 async def test_create_wallet():
     """Ensure a user can create a wallet."""
     pass
 
 
+@pytest.mark.asyncio
 async def test_get_wallets():
     """Ensure an authenticated user can get their wallets."""
     pass
 
 
+@pytest.mark.asyncio
 async def test_deposit_money():
     """Ensure an authenticated user can deposit money."""
     pass
 
 
+@pytest.mark.asyncio
 async def test_withdraw_money():
     """Ensure an authenticated user can withdraw money."""
     pass
 
 
+@pytest.mark.asyncio
 async def test_wallet_to_wallet_transfer():
     """Ensure an authenticated user can transfer from x to y wallet."""
     pass
 
 
+@pytest.mark.asyncio
 async def test_wallet_to_user_transfer():
     """Ensure an authenticated user can transfer his their account to
     another user's account."""
     pass
 
 
+@pytest.mark.asyncio
 async def test_total_wallet_balance():
     """Ensure an authenticated user can get the total balance of their wallets."""
     pass
 
 
+@pytest.mark.asyncio
 async def test_wallet_balance():
     """Ensure an authenticated user can get the balance of a particular wallet."""
     pass

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -12,7 +12,7 @@ async def login_user():
 
 @pytest.mark.asyncio
 async def test_create_wallet():
-    """Ensure a user can create a wallet."""
+    """Ensure an authenticated user can create a wallet."""
     pass
 
 
@@ -42,7 +42,7 @@ async def test_wallet_to_wallet_transfer():
 
 @pytest.mark.asyncio
 async def test_wallet_to_user_transfer():
-    """Ensure an authenticated user can transfer his their account to
+    """Ensure an authenticated user can transfer their account to
     another user's account."""
     pass
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -26,6 +26,8 @@ password = name + "_weakpassword"
 
 @pytest.mark.asyncio
 async def test_create_user():
+    """Ensure a user can register."""
+    
     payload = {
         "name": name,
         "email": email,
@@ -41,6 +43,8 @@ async def test_create_user():
 
 @pytest.mark.asyncio
 async def test_login_user_success():
+    """Ensure a user can login successfully."""
+    
     payload = {"email": email, "password": password}
     response = client.post("/login/", data=json.dumps(payload))
 
@@ -49,6 +53,8 @@ async def test_login_user_success():
 
 @pytest.mark.asyncio
 async def test_login_user_password_incorrect():
+    """Ensure a user with incorrect password can not login."""
+    
     payload = {"email": email, "password": "string"}
     response = client.post("/login/", data=json.dumps(payload))
 
@@ -58,6 +64,8 @@ async def test_login_user_password_incorrect():
 
 @pytest.mark.asyncio
 async def test_login_user_password_not_exist():
+    """Ensure a user that has no account can not login."""
+    
     payload = {"email": "user@example.com", "password": "string"}
     response = client.post("/login/", data=json.dumps(payload))
 
@@ -67,6 +75,7 @@ async def test_login_user_password_not_exist():
 
 @pytest.mark.asyncio
 async def test_users_info():
+    """Ensure an authenticated user with admin priviledges can get a list of users info."""
 
     # set up fake credentials for admin user
     admin_name = "".join(
@@ -100,6 +109,7 @@ async def test_users_info():
 
 @pytest.mark.asyncio
 async def test_user_info():
+    """Ensure an authenticated user can get their info."""
 
     login_response = client.post(
         "/login/", data=json.dumps({"email": email, "password": password})

--- a/users/router.py
+++ b/users/router.py
@@ -3,13 +3,7 @@ from fastapi import APIRouter, Depends
 
 # Own Imports
 from auth.auth_bearer import jwt_bearer
-from core.deps import get_db
 
 
 # initialize router
-router = APIRouter(
-    dependencies=[
-        Depends(jwt_bearer),
-        Depends(get_db),
-    ]
-)
+router = APIRouter(dependencies=[Depends(jwt_bearer)])


### PR DESCRIPTION
The following was worked on:

- removed `get_db` dependency from API routers
- removed the `SessionLocal` class from orms initialization
- the `ORMSessionMixin` will use the test database pool if the configuration (`USE_TEST_DB`) is set, otherwise; it will use the default database
- implemented test cases for ledger API views
- added docstrings to test cases